### PR TITLE
Réglages opérateur modifiables et persistants (flash)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+* text=auto eol=lf
+
+*.uf2 binary
+*.jpg binary
+*.bmp binary
+*.png binary

--- a/.gitignore
+++ b/.gitignore
@@ -111,3 +111,11 @@ $RECYCLE.BIN/
 *.lnk
 
 # End of https://www.toptal.com/developers/gitignore/api/rust,visualstudiocode,macos,windows,linux
+data/
+
+# Binaires de flash — seules les sources sont versionnées.
+*.uf2
+
+# Captures regénérées par cargo test-host — pas versionnées.
+screenshots/
+screenshot.png

--- a/src/config/mod.rs
+++ b/src/config/mod.rs
@@ -6,6 +6,10 @@
 //! - [`operating`] : réglages physiques ajustables (cibles, tolérances,
 //!   seuils de sécurité) — plusieurs sont déjà exposés comme valeurs par
 //!   défaut modifiables dans `ui::screens::settings`.
+//! - [`settings`] : version modifiable en marche des cibles ci-dessus, et
+//!   abstraction du support de stockage persistant. `operating` reste la
+//!   source de vérité des valeurs par défaut ; `settings` porte l'état
+//!   courant, modifié en session.
 //!
 //! Le timing de la boucle de contrôle (timeouts, délais de séquence) vit à
 //! part dans [`crate::logic::timing`], au plus près du code qui l'utilise,
@@ -15,4 +19,5 @@
 //! paramètres de type, et ne doit pas dépendre de ce module.
 
 pub mod operating;
+pub mod settings;
 pub mod wiring;

--- a/src/config/settings.rs
+++ b/src/config/settings.rs
@@ -1,0 +1,244 @@
+//! Version modifiable en marche des cibles de [`super::operating`], et
+//! abstraction du support de stockage persistant.
+//!
+//! Vit dans `config/` plutôt que dans `cloud_chamber_hal` : `Settings`
+//! dépend de `super::operating` pour ses valeurs par défaut, et le HAL ne
+//! doit jamais dépendre de `crate::config` (sens de dépendance inverse,
+//! cf. doc de `config/mod.rs`).
+//!
+//! Les seuils de sécurité (`SAFETY_TEMP_COMPRESSOR_MAX`) n'y sont pas :
+//! une limite qu'on peut changer depuis un menu n'est plus une limite, et
+//! elle deviendrait aussi modifiable par une corruption de flash. Ils
+//! restent des constantes compilées dans `operating.rs`. Même raisonnement
+//! pour `sensor_loss_ms` (protection de sécurité, `logic::security`) et
+//! `regulation_band` (encore consommé nulle part) : laissés de côté pour
+//! l'instant plutôt que persistés sans lecteur ou avec une lecture
+//! partielle qui donnerait une fausse impression de contrôle.
+//!
+//! # Pourquoi sérialiser champ par champ
+//!
+//! La tentation est d'écrire les octets bruts d'une `#[repr(C)]`. Mais le
+//! padding entre champs de tailles différentes n'est pas initialisé : le
+//! CRC changerait d'un build à l'autre sans que la moindre valeur ait
+//! bougé. On écrit donc chaque champ explicitement, en petit-boutiste, ce
+//! qui fixe aussi la représentation si on change un jour de cible.
+
+use crate::cloud_chamber_hal::units::Celsius;
+
+/// Version du schéma. À incrémenter dès qu'un champ est ajouté, retiré ou
+/// change de sens — une version inconnue fait repartir sur les défauts
+/// plutôt que de relire les anciens octets en décalé.
+pub const SETTINGS_VERSION: u16 = 1;
+
+/// Repère de début d'enregistrement. Une flash vierge est à `0xFF` partout ;
+/// sans ce motif on relirait ces `0xFF` comme des `f32` valant `NaN`, et la
+/// chambre démarrerait sur des consignes NaN.
+const MAGIC: u32 = 0x43_43_53_31; // "CCS1"
+
+const HEADER_LEN: usize = 8; // magic + version + longueur utile
+const PAYLOAD_LEN: usize = 4 * 4; // 4 f32
+const CRC_LEN: usize = 4;
+
+/// Taille totale de l'enregistrement écrit en flash.
+pub const RECORD_LEN: usize = HEADER_LEN + PAYLOAD_LEN + CRC_LEN;
+
+/// Cibles modifiables en marche, sauvegardées entre deux démarrages.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub struct Settings {
+    pub chamber_target: Celsius,
+    pub precool_target: Celsius,
+    pub saturation_target: Celsius,
+    pub ipa_heater_target: Celsius,
+}
+
+/// Ce que le stockage peut refuser de faire.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StoreError {
+    /// L'écriture matérielle a échoué.
+    Write,
+    /// Relecture après écriture non conforme — la flash n'a pas pris.
+    Verify,
+}
+
+/// Support de stockage persistant. `logic/` et `ui/` ne connaissent que ce
+/// trait ; savoir ce qu'est un secteur de flash est le travail du driver.
+pub trait SettingsStore {
+    /// Relit les réglages. `None` si rien n'a jamais été écrit, ou si
+    /// l'enregistrement est illisible — l'appelant repart alors sur
+    /// `Settings::defaults()`.
+    fn load(&mut self) -> Option<Settings>;
+
+    /// Écrit les réglages. Opération lente et limitée en nombre de cycles :
+    /// à n'appeler que sur demande explicite de l'opérateur, jamais à chaque
+    /// cran d'encodeur.
+    fn save(&mut self, settings: &Settings) -> Result<(), StoreError>;
+}
+
+impl Settings {
+    /// Valeurs de repli, identiques aux constantes de `super::operating`.
+    ///
+    /// C'est la seule source de vérité au premier démarrage, après une
+    /// corruption, et après un changement de version de schéma.
+    pub const fn defaults() -> Self {
+        use super::operating::*;
+        Self {
+            chamber_target: Celsius(TARGET_CHAMBER_TEMP),
+            precool_target: Celsius(PRECOOL_TARGET_C),
+            saturation_target: Celsius(SATURATION_TARGET_C),
+            ipa_heater_target: Celsius(IPA_HEATER_TARGET_C),
+        }
+    }
+
+    /// Sérialise en un bloc de taille fixe, prêt à écrire.
+    pub fn to_bytes(&self) -> [u8; RECORD_LEN] {
+        let mut out = [0u8; RECORD_LEN];
+        out[0..4].copy_from_slice(&MAGIC.to_le_bytes());
+        out[4..6].copy_from_slice(&SETTINGS_VERSION.to_le_bytes());
+        out[6..8].copy_from_slice(&(PAYLOAD_LEN as u16).to_le_bytes());
+
+        let mut at = HEADER_LEN;
+        for value in self.floats() {
+            out[at..at + 4].copy_from_slice(&value.to_le_bytes());
+            at += 4;
+        }
+
+        let crc = crc32(&out[..at]);
+        out[at..at + 4].copy_from_slice(&crc.to_le_bytes());
+        out
+    }
+
+    /// Relit un bloc. `None` dès que quelque chose ne colle pas — motif
+    /// absent, version inconnue, longueur inattendue, CRC faux. On ne
+    /// tente aucune récupération partielle : une valeur à moitié juste
+    /// serait pire qu'un retour aux défauts.
+    pub fn from_bytes(raw: &[u8; RECORD_LEN]) -> Option<Self> {
+        if u32::from_le_bytes(raw[0..4].try_into().ok()?) != MAGIC {
+            return None;
+        }
+        if u16::from_le_bytes(raw[4..6].try_into().ok()?) != SETTINGS_VERSION {
+            return None;
+        }
+        if u16::from_le_bytes(raw[6..8].try_into().ok()?) as usize != PAYLOAD_LEN {
+            return None;
+        }
+        let end = HEADER_LEN + PAYLOAD_LEN;
+        if crc32(&raw[..end]) != u32::from_le_bytes(raw[end..end + 4].try_into().ok()?) {
+            return None;
+        }
+
+        let mut at = HEADER_LEN;
+        let mut floats = [0.0f32; 4];
+        for slot in floats.iter_mut() {
+            *slot = f32::from_le_bytes(raw[at..at + 4].try_into().ok()?);
+            at += 4;
+        }
+
+        // Un CRC juste ne garantit qu'une chose : les octets sont ceux qu'on
+        // a écrits. Il ne dit pas qu'ils ont du sens — un NaN écrit par un
+        // bug se relirait proprement. On refuse donc aussi les non-finis.
+        if floats.iter().any(|v| !v.is_finite()) {
+            return None;
+        }
+
+        Some(Self {
+            chamber_target: Celsius(floats[0]),
+            precool_target: Celsius(floats[1]),
+            saturation_target: Celsius(floats[2]),
+            ipa_heater_target: Celsius(floats[3]),
+        })
+    }
+
+    /// Ordre de sérialisation des champs. Cet ordre fait partie du format :
+    /// le changer sans toucher `SETTINGS_VERSION` casserait la relecture
+    /// des enregistrements existants.
+    fn floats(&self) -> [f32; 4] {
+        [
+            self.chamber_target.0,
+            self.precool_target.0,
+            self.saturation_target.0,
+            self.ipa_heater_target.0,
+        ]
+    }
+}
+
+impl Default for Settings {
+    fn default() -> Self {
+        Self::defaults()
+    }
+}
+
+/// CRC-32 (polynôme IEEE réfléchi), calculé bit à bit.
+///
+/// La version par table est plus rapide mais coûte 1 ko de flash pour la
+/// table. Ici on couvre une trentaine d'octets, deux fois par sauvegarde :
+/// la vitesse n'a aucune importance, la place si.
+fn crc32(data: &[u8]) -> u32 {
+    let mut crc = 0xFFFF_FFFFu32;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            let mask = (crc & 1).wrapping_neg();
+            crc = (crc >> 1) ^ (0xEDB8_8320 & mask);
+        }
+    }
+    !crc
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn round_trip_preserves_every_field() {
+        let mut settings = Settings::defaults();
+        settings.chamber_target = Celsius(-41.5);
+        settings.ipa_heater_target = Celsius(38.0);
+
+        let decoded = Settings::from_bytes(&settings.to_bytes()).unwrap();
+        assert_eq!(decoded, settings);
+    }
+
+    #[test]
+    fn blank_flash_is_rejected() {
+        // Cas du Pico neuf : tout à 0xFF. Relu naïvement, ça donnerait des
+        // NaN — c'est précisément ce que le motif doit intercepter.
+        assert!(Settings::from_bytes(&[0xFF; RECORD_LEN]).is_none());
+    }
+
+    #[test]
+    fn zeroed_flash_is_rejected() {
+        assert!(Settings::from_bytes(&[0x00; RECORD_LEN]).is_none());
+    }
+
+    #[test]
+    fn a_single_flipped_bit_is_caught() {
+        let mut raw = Settings::defaults().to_bytes();
+        raw[HEADER_LEN] ^= 0x01;
+        assert!(Settings::from_bytes(&raw).is_none());
+    }
+
+    #[test]
+    fn unknown_version_falls_back() {
+        let mut raw = Settings::defaults().to_bytes();
+        raw[4..6].copy_from_slice(&(SETTINGS_VERSION + 1).to_le_bytes());
+        assert!(Settings::from_bytes(&raw).is_none());
+    }
+
+    #[test]
+    fn non_finite_value_is_rejected() {
+        // Un NaN écrit par un bug passerait le CRC : il est bien "celui
+        // qu'on a écrit". C'est le contrôle de finitude qui l'arrête.
+        let mut settings = Settings::defaults();
+        settings.chamber_target = Celsius(f32::NAN);
+        assert!(Settings::from_bytes(&settings.to_bytes()).is_none());
+    }
+
+    #[test]
+    fn crc_matches_a_known_vector() {
+        // Vecteur de référence du CRC-32 IEEE, pour vérifier que c'est bien
+        // ce polynôme-là et pas une variante maison.
+        assert_eq!(crc32(b"123456789"), 0xCBF4_3926);
+    }
+}

--- a/src/drivers/flash_store.rs
+++ b/src/drivers/flash_store.rs
@@ -1,0 +1,341 @@
+//! Stockage des réglages dans la flash interne, sans système de fichiers.
+//!
+//! # Pourquoi pas un JSON
+//!
+//! Un fichier suppose un système de fichiers, donc une couche (LittleFS,
+//! FAT) et un parseur JSON, pour ranger quelques octets. On écrit
+//! directement la struct sérialisée par [`Settings::to_bytes`], protégée
+//! par un magic, une version et un CRC. Lire les réglages devient une
+//! comparaison de quatre octets et un CRC, pas une machine à états.
+//!
+//! # Découpage
+//!
+//! Ce module ne sait pas parler au contrôleur de flash. Il connaît la
+//! *disposition* : un secteur, seize emplacements, écriture en avançant.
+//! Les trois opérations matérielles (lire, effacer, programmer) passent par
+//! [`FlashOps`], implémenté d'un côté par le vrai driver ROM, de l'autre
+//! par un tableau en RAM dans les tests. C'est ce qui rend la logique
+//! d'usure testable sur PC, là où elle est invérifiable sur cible.
+//!
+//! # Écriture en avançant plutôt qu'en place
+//!
+//! La flash s'efface par secteur de 4 Ko et supporte de l'ordre de 100 000
+//! effacements. Réécrire toujours au même endroit coûterait un effacement
+//! par sauvegarde. On garde donc seize emplacements de 256 octets dans le
+//! secteur et on programme le premier resté vierge ; le secteur n'est
+//! effacé que lorsqu'ils sont tous pris, soit une fois toutes les seize
+//! sauvegardes. Un emplacement neuf n'a pas besoin d'être effacé : une
+//! flash vierge est à 0xFF et programmer ne fait que descendre des bits
+//! à 0.
+//!
+//! # Ce qui reste à écrire : l'implémentation `FlashOps` sur cible
+//!
+//! Sur RP2040 comme sur RP2350, effacer et programmer se font par les
+//! routines de la ROM (`connect_internal_flash`, `flash_exit_xip`,
+//! `flash_range_erase`, `flash_range_program`, `flash_flush_cache`,
+//! `flash_enter_cmd_xip`). Deux contraintes non négociables :
+//!
+//! - la séquence coupe le XIP, donc le code qui l'exécute ne peut pas être
+//!   *dans* la flash : la fonction doit être en RAM
+//!   (`#[link_section = ".data.ram_func"]` + `#[inline(never)]`) ;
+//! - aucune interruption ne doit toucher la flash pendant ce temps, d'où
+//!   un `critical_section::with` autour, et rien qui puisse s'exécuter sur
+//!   le second cœur.
+//!
+//! Cette partie n'est pas écrite ici tant qu'elle n'a pas été compilée et
+//! passée sur la vraie carte : c'est une vingtaine de lignes d'`unsafe` qui
+//! briquent la carte si elles sont fausses, et elles ne se relisent pas,
+//! elles se testent.
+
+use crate::config::settings::{RECORD_LEN, Settings, SettingsStore, StoreError};
+
+// Ces deux constantes n'ont pas de source amont à laquelle se rattacher, et
+// ce n'est pas un oubli : elles ne décrivent pas le microcontrôleur mais la
+// puce QSPI soudée à côté. Le RP2040 n'a pas de flash interne du tout, et le
+// Pico 2 utilise aussi une flash externe. `rp2040_hal::rom_data` expose bien
+// les six fonctions ROM (`connect_internal_flash`, `flash_exit_xip`,
+// `flash_range_erase`, `flash_range_program`, `flash_flush_cache`,
+// `flash_enter_cmd_xip`) mais aucune constante de géométrie, et les scripts
+// de link (`rp2040.x`, `rp2350.x`) ne déclarent que l'origine et la longueur
+// de la région FLASH. Le HAL ne peut pas les connaître : il ne sait pas quel
+// boîtier est monté.
+//
+// Ce qui, lui, devrait venir du script de link, c'est l'*adresse* du secteur
+// des réglages — cf. `FlashSettingsStore::new`.
+
+/// Taille du secteur d'effacement de la flash QSPI (famille W25Q, 4 Ko).
+pub const SECTOR_SIZE: usize = 4096;
+
+/// Taille de la page de programmation. C'est aussi la taille d'un
+/// emplacement : programmer moins qu'une page entière est possible, mais
+/// aligner les emplacements sur les pages évite qu'une sauvegarde touche
+/// deux pages à la fois.
+pub const PAGE_SIZE: usize = 256;
+
+/// Nombre de sauvegardes tenables avant qu'un effacement soit nécessaire.
+pub const SLOTS: usize = SECTOR_SIZE / PAGE_SIZE;
+
+// Un enregistrement doit tenir dans une page, sinon `save` en écrirait deux
+// et la coupure de courant entre les deux laisserait un état à moitié écrit
+// que la relecture ne saurait pas détecter. Vérifié à la compilation plutôt
+// que par un test : ça vaut pour toutes les cibles, pas seulement l'hôte.
+const _: () = assert!(RECORD_LEN <= PAGE_SIZE);
+
+/// Les trois seules choses qu'on demande au matériel.
+///
+/// Les décalages sont comptés depuis le début de la flash, pas depuis la
+/// fenêtre XIP : c'est ce qu'attendent les routines ROM.
+pub trait FlashOps {
+    /// Lit `buf.len()` octets. La lecture passe par le XIP, elle n'a besoin
+    /// d'aucune précaution.
+    fn read(&self, offset: u32, buf: &mut [u8]);
+
+    /// Efface un secteur entier — `offset` doit être aligné sur
+    /// [`SECTOR_SIZE`].
+    fn erase_sector(&mut self, offset: u32) -> Result<(), StoreError>;
+
+    /// Programme une page — `offset` doit être aligné sur [`PAGE_SIZE`].
+    fn program_page(&mut self, offset: u32, page: &[u8; PAGE_SIZE]) -> Result<(), StoreError>;
+}
+
+/// Implémente [`SettingsStore`] au-dessus d'un secteur de flash.
+pub struct FlashSettingsStore<F> {
+    flash: F,
+    /// Décalage du secteur réservé aux réglages. Il doit tomber hors du
+    /// binaire : le script de link réserve le dernier secteur.
+    base: u32,
+}
+
+impl<F: FlashOps> FlashSettingsStore<F> {
+    /// `base` doit être aligné sur [`SECTOR_SIZE`], sinon l'effacement
+    /// emporterait le secteur voisin — c'est-à-dire, ici, du code.
+    ///
+    /// À terme cette valeur ne devrait pas être écrite en dur par
+    /// l'appelant mais venir du script de link, qui est le seul endroit à
+    /// connaître la taille réelle de la flash de la carte : un symbole
+    /// placé en fin de région FLASH, réservé pour qu'aucune section n'y
+    /// atterrisse. C'est la seule façon d'être sûr que le secteur ne
+    /// recouvre pas le binaire.
+    pub fn new(flash: F, base: u32) -> Self {
+        debug_assert!(
+            base as usize % SECTOR_SIZE == 0,
+            "le secteur des reglages doit etre aligne"
+        );
+        Self { flash, base }
+    }
+
+    fn slot_offset(&self, slot: usize) -> u32 {
+        self.base + (slot * PAGE_SIZE) as u32
+    }
+
+    /// Lit l'enregistrement d'un emplacement. `None` si l'emplacement est
+    /// vierge — inutile de vérifier un CRC sur du 0xFF.
+    fn read_slot(&self, slot: usize) -> Option<[u8; RECORD_LEN]> {
+        let mut raw = [0u8; RECORD_LEN];
+        self.flash.read(self.slot_offset(slot), &mut raw);
+        if raw.iter().all(|&b| b == 0xFF) {
+            return None;
+        }
+        Some(raw)
+    }
+
+    /// Rang du premier emplacement vierge, `None` si le secteur est plein.
+    ///
+    /// On s'arrête au premier vierge sans regarder la suite : l'écriture
+    /// avance toujours dans le même sens, donc tout ce qui suit l'est aussi.
+    fn first_blank_slot(&self) -> Option<usize> {
+        (0..SLOTS).find(|&slot| self.read_slot(slot).is_none())
+    }
+}
+
+impl<F: FlashOps> SettingsStore for FlashSettingsStore<F> {
+    /// Remonte les emplacements du plus récent au plus ancien et renvoie le
+    /// premier qui se relit correctement.
+    ///
+    /// Descendre plutôt que s'arrêter au dernier écrit couvre le cas d'une
+    /// coupure de courant en pleine programmation : l'emplacement en cours
+    /// est à moitié écrit et son CRC tombe faux, mais le précédent est
+    /// intact, et c'est celui-là qu'on veut.
+    fn load(&mut self) -> Option<Settings> {
+        (0..SLOTS)
+            .rev()
+            .filter_map(|slot| self.read_slot(slot))
+            .find_map(|raw| Settings::from_bytes(&raw))
+    }
+
+    fn save(&mut self, settings: &Settings) -> Result<(), StoreError> {
+        // Le reste de la page reste à 0xFF, ce qui est justement ce qui
+        // signale « emplacement vierge » aux relectures suivantes.
+        let mut page = [0xFFu8; PAGE_SIZE];
+        page[..RECORD_LEN].copy_from_slice(&settings.to_bytes());
+
+        let slot = match self.first_blank_slot() {
+            Some(slot) => slot,
+            None => {
+                self.flash.erase_sector(self.base)?;
+                0
+            }
+        };
+
+        let offset = self.slot_offset(slot);
+        self.flash.program_page(offset, &page)?;
+
+        // La ROM ne dit pas si la cellule a pris. On relit : un secteur en
+        // fin de vie accepte l'ordre d'écriture sans changer d'état, et on
+        // préfère le savoir maintenant que sous forme de réglages disparus
+        // au prochain démarrage.
+        let mut back = [0u8; PAGE_SIZE];
+        self.flash.read(offset, &mut back);
+        if back != page {
+            return Err(StoreError::Verify);
+        }
+
+        Ok(())
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cloud_chamber_hal::units::Celsius;
+
+    /// Flash simulée : un secteur en RAM, avec la sémantique qui compte —
+    /// programmer ne fait que descendre des bits, seul l'effacement remonte.
+    struct MockFlash {
+        data: [u8; SECTOR_SIZE],
+        erases: usize,
+        /// Nombre de programmations avant de refuser la suivante.
+        fail_after: Option<usize>,
+        programs: usize,
+        /// Simule une cellule morte : le bit de poids fort du premier octet
+        /// programmé ne descend jamais.
+        stuck_bit: bool,
+    }
+
+    impl MockFlash {
+        fn new() -> Self {
+            Self {
+                data: [0xFF; SECTOR_SIZE],
+                erases: 0,
+                fail_after: None,
+                programs: 0,
+                stuck_bit: false,
+            }
+        }
+    }
+
+    impl FlashOps for MockFlash {
+        fn read(&self, offset: u32, buf: &mut [u8]) {
+            let start = offset as usize;
+            buf.copy_from_slice(&self.data[start..start + buf.len()]);
+        }
+
+        fn erase_sector(&mut self, offset: u32) -> Result<(), StoreError> {
+            assert_eq!(offset as usize % SECTOR_SIZE, 0);
+            self.data = [0xFF; SECTOR_SIZE];
+            self.erases += 1;
+            Ok(())
+        }
+
+        fn program_page(&mut self, offset: u32, page: &[u8; PAGE_SIZE]) -> Result<(), StoreError> {
+            assert_eq!(offset as usize % PAGE_SIZE, 0);
+            if let Some(limit) = self.fail_after {
+                if self.programs >= limit {
+                    return Err(StoreError::Write);
+                }
+            }
+            let start = offset as usize;
+            for (cell, &wanted) in self.data[start..start + PAGE_SIZE].iter_mut().zip(page) {
+                // Programmer ne peut que mettre des bits à 0.
+                *cell &= wanted;
+            }
+            if self.stuck_bit {
+                self.data[start] |= 0x80;
+            }
+            self.programs += 1;
+            Ok(())
+        }
+    }
+
+    fn store() -> FlashSettingsStore<MockFlash> {
+        FlashSettingsStore::new(MockFlash::new(), 0)
+    }
+
+    #[test]
+    fn blank_flash_has_nothing_to_load() {
+        assert!(store().load().is_none());
+    }
+
+    #[test]
+    fn what_was_saved_comes_back() {
+        let mut s = store();
+        let mut settings = Settings::defaults();
+        settings.chamber_target = Celsius(-38.5);
+        settings.ipa_heater_target = Celsius(42.0);
+
+        s.save(&settings).unwrap();
+        assert_eq!(s.load(), Some(settings));
+    }
+
+    #[test]
+    fn the_newest_record_wins() {
+        let mut s = store();
+        for i in 0..5 {
+            let mut settings = Settings::defaults();
+            settings.chamber_target = Celsius(-30.0 - i as f32);
+            s.save(&settings).unwrap();
+        }
+        assert_eq!(s.load().unwrap().chamber_target, Celsius(-34.0));
+    }
+
+    #[test]
+    fn the_sector_is_erased_only_once_it_is_full() {
+        let mut s = store();
+        let settings = Settings::defaults();
+
+        for _ in 0..SLOTS {
+            s.save(&settings).unwrap();
+        }
+        assert_eq!(s.flash.erases, 0, "seize sauvegardes tiennent sans effacer");
+
+        s.save(&settings).unwrap();
+        assert_eq!(s.flash.erases, 1);
+        assert_eq!(s.load(), Some(settings), "et on relit toujours quelque chose");
+    }
+
+    #[test]
+    fn a_torn_write_falls_back_to_the_previous_record() {
+        let mut s = store();
+        let good = Settings::defaults();
+        s.save(&good).unwrap();
+
+        let mut half_written = Settings::defaults();
+        half_written.chamber_target = Celsius(-12.0);
+        s.save(&half_written).unwrap();
+        // Coupure de courant juste après l'en-tête : tout ce qui suit est
+        // resté à 0xFF. Le magic est là, donc l'emplacement compte comme
+        // occupé, mais les consignes s'y relisent en NaN et
+        // `Settings::from_bytes` refuse.
+        s.flash.data[PAGE_SIZE + 8..PAGE_SIZE + RECORD_LEN].fill(0xFF);
+
+        assert_eq!(s.load(), Some(good));
+    }
+
+    #[test]
+    fn a_write_failure_is_reported() {
+        let mut s = FlashSettingsStore::new(
+            MockFlash { fail_after: Some(0), ..MockFlash::new() },
+            0,
+        );
+        assert_eq!(s.save(&Settings::defaults()), Err(StoreError::Write));
+    }
+
+    #[test]
+    fn flash_that_does_not_take_is_caught_by_the_readback() {
+        let mut s =
+            FlashSettingsStore::new(MockFlash { stuck_bit: true, ..MockFlash::new() }, 0);
+        assert_eq!(s.save(&Settings::defaults()), Err(StoreError::Verify));
+    }
+}

--- a/src/drivers/mod.rs
+++ b/src/drivers/mod.rs
@@ -50,6 +50,10 @@ pub mod lights;
 /// Driver chauffage de la vitre supérieure : sortie GPIO tout-ou-rien (marche/arrêt).
 pub mod window_heater;
 
+/// Stockage persistant des réglages (`config::settings::Settings`) dans la
+/// flash interne, sans système de fichiers.
+pub mod flash_store;
+
 /// Capteurs mock (température/pression/tension) pour les tests — pas de
 /// matériel, valeurs configurables. Compilé uniquement sous `cargo test`.
 #[cfg(test)]

--- a/src/logic/control_loop.rs
+++ b/src/logic/control_loop.rs
@@ -3,11 +3,11 @@
 use crate::{cloud_chamber_hal::{
     actuators::{ActuatorPlan, Actuators, BinaryActuator, TargetActuator}, config::{CHAMBER_TEMP_IDX, ISO_TEMP_IDX, NUMBER_OF_PRESSURE_SENSOR, NUMBER_OF_TEMP_SENSOR}, sensors::{BatchSensor, DeferredBatchSensor, Sensors}, timer::MonotonicTimer, units::{Celsius, HectoPascal},
 }};
-use crate::config::operating::{IPA_HEATER_TARGET_C, SATURATION_TARGET_C};
 use crate::logic::timing::CONTROL_LOOP_HISTORY_SIZE;
 use crate::logic::phase_clock::{PhaseClock, advance};
 use crate::logic::security::{SafetyConfig, SafetyMonitor};
 use crate::shared::data::{SHARED_STATE, SensorSnapshot, SystemTask};
+use crate::shared::settings;
 
 use super::probing::{MeasurementHistory, ProbingPlan};
 
@@ -190,15 +190,18 @@ impl SystemTask {
             // pour un compresseur en régime permanent. Pas de sortie
             // automatique — seul un arrêt opérateur explicite (signal UI,
             // pas câblé ici) fait sortir de cet état.
-            Stabilising => (
-                SystemTask::Stabilising,
-                ActuatorPlan {
-                    cooling: Some(Celsius(SATURATION_TARGET_C)),
-                    iso_heater: Some(Celsius(IPA_HEATER_TARGET_C)),
-                    high_voltage: true,
-                    iso_pump: false, lights: None, glass_heater: false,
-                },
-            ),
+            Stabilising => {
+                let settings = settings::get();
+                (
+                    SystemTask::Stabilising,
+                    ActuatorPlan {
+                        cooling: Some(settings.saturation_target),
+                        iso_heater: Some(settings.ipa_heater_target),
+                        high_voltage: true,
+                        iso_pump: false, lights: None, glass_heater: false,
+                    },
+                )
+            }
             Stopping(phase) => phase.react_to(history),
             // Coupure de secours : tout éteint, verrouillé jusqu'au
             // réarmement opérateur explicite (`SafetyMonitor::reset`, appelé
@@ -263,7 +266,7 @@ mod tests {
     };
     use crate::cloud_chamber_hal::measurement::Measurement;
     use crate::cloud_chamber_hal::timer::Instant;
-    use crate::config::operating::{PRECOOL_TARGET_C, SATURATION_TARGET_C};
+    use crate::config::operating::{IPA_HEATER_TARGET_C, PRECOOL_TARGET_C, SATURATION_TARGET_C};
     use crate::logic::timing::{
         IPA_CIRCULATION_MS, PRECOOL_TIMEOUT_MS, SENSOR_CHECK_TIMEOUT_MS, SENSOR_LOSS_MS,
         STOP_COMPRESSOR_SETTLE_MS, STOP_EQUALIZE_FALLBACK_MS, STOP_HV_SETTLE_MS,
@@ -284,6 +287,12 @@ mod tests {
     /// Remet `SHARED_STATE` à un état par défaut connu et exécute `body`
     /// sous verrou exclusif — chaque test démarre donc d'un état propre,
     /// indépendant de l'ordre d'exécution.
+    ///
+    /// Réinitialise aussi `shared::settings` (verrou séparé, static
+    /// différent) : `cooling.rs`/`stopping.rs`/`Stabilising` lisent
+    /// `shared::settings::get()` dans leur chemin normal, donc tout test
+    /// qui les exerce (la quasi-totalité de ce module) y est exposé au
+    /// même risque de parallélisme que sur `SHARED_STATE`.
     fn with_isolated_shared_state<T>(body: impl FnOnce() -> T) -> T {
         let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
         critical_section::with(|cs| {
@@ -292,7 +301,7 @@ mod tests {
             s.task = SystemTask::Idle;
             s.new_data = false;
         });
-        body()
+        crate::shared::settings::with_isolated_settings(body)
     }
 
     // ─── Harness ──────────────────────────────────────────────────────────

--- a/src/logic/cooling.rs
+++ b/src/logic/cooling.rs
@@ -8,13 +8,11 @@
 //! qui seul connaît la durée passée dans la phase courante.
 
 use crate::cloud_chamber_hal::config::CHAMBER_TEMP_IDX;
-use crate::cloud_chamber_hal::units::Celsius;
-use crate::config::operating::{
-    IPA_HEATER_TARGET_C, PRECOOL_TARGET_C, SATURATION_TARGET_C, STABLE_TOLERANCE_C, STABLE_WINDOW_MS,
-};
+use crate::config::operating::{STABLE_TOLERANCE_C, STABLE_WINDOW_MS};
 use crate::cloud_chamber_hal::actuators::ActuatorPlan;
 use crate::logic::probing::{MeasurementHistory, ProbingPlan};
 use crate::shared::data::SystemTask;
+use crate::shared::settings;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum CoolingPhase {
@@ -67,12 +65,13 @@ fn sensor_check(history: &MeasurementHistory) -> (SystemTask, ActuatorPlan) {
 }
 
 fn pre_cooling_the_plate(history: &MeasurementHistory) -> (SystemTask, ActuatorPlan) {
+    let precool_target = settings::get().precool_target;
     let plan = ActuatorPlan {
-        cooling: Some(Celsius(PRECOOL_TARGET_C)), iso_heater: None, high_voltage: false,
+        cooling: Some(precool_target), iso_heater: None, high_voltage: false,
         iso_pump: false, lights: None, glass_heater: false,
     };
     match history.temps[CHAMBER_TEMP_IDX].get(0) {
-        Ok(m) if !m.value.0.is_nan() && m.value.0 <= PRECOOL_TARGET_C =>
+        Ok(m) if !m.value.0.is_nan() && m.value.0 <= precool_target.0 =>
             (SystemTask::Cooling(CoolingPhase::StartingIpaCirculation), plan),
         _ => (SystemTask::Cooling(CoolingPhase::PreCoolingThePlate), plan),
     }
@@ -81,32 +80,35 @@ fn pre_cooling_the_plate(history: &MeasurementHistory) -> (SystemTask, ActuatorP
 fn starting_ipa_circulation(_history: &MeasurementHistory) -> (SystemTask, ActuatorPlan) {
     // Purement temporisé (pas de capteur dédié) — avancement décidé par
     // l'appelant (cf. `timed_transition` dans control_loop.rs).
+    let settings = settings::get();
     (SystemTask::Cooling(CoolingPhase::StartingIpaCirculation), ActuatorPlan {
-        cooling: Some(Celsius(PRECOOL_TARGET_C)),
-        iso_heater: Some(Celsius(IPA_HEATER_TARGET_C)),
+        cooling: Some(settings.precool_target),
+        iso_heater: Some(settings.ipa_heater_target),
         high_voltage: false,
         iso_pump: false, lights: None, glass_heater: false,
     })
 }
 
 fn saturating_air_with_ipa(history: &MeasurementHistory) -> (SystemTask, ActuatorPlan) {
+    let settings = settings::get();
     let plan = ActuatorPlan {
-        cooling: Some(Celsius(SATURATION_TARGET_C)),
-        iso_heater: Some(Celsius(IPA_HEATER_TARGET_C)),
+        cooling: Some(settings.saturation_target),
+        iso_heater: Some(settings.ipa_heater_target),
         high_voltage: false,
         iso_pump: false, lights: None, glass_heater: false,
     };
     match history.temps[CHAMBER_TEMP_IDX].get(0) {
-        Ok(m) if !m.value.0.is_nan() && m.value.0 <= SATURATION_TARGET_C =>
+        Ok(m) if !m.value.0.is_nan() && m.value.0 <= settings.saturation_target.0 =>
             (SystemTask::Cooling(CoolingPhase::HighVoltage), plan),
         _ => (SystemTask::Cooling(CoolingPhase::SaturatingAirWithIpa), plan),
     }
 }
 
 fn high_voltage(history: &MeasurementHistory) -> (SystemTask, ActuatorPlan) {
+    let settings = settings::get();
     let plan = ActuatorPlan {
-        cooling: Some(Celsius(SATURATION_TARGET_C)),
-        iso_heater: Some(Celsius(IPA_HEATER_TARGET_C)),
+        cooling: Some(settings.saturation_target),
+        iso_heater: Some(settings.ipa_heater_target),
         high_voltage: true,
         iso_pump: false, lights: Some(true), glass_heater: false,
     };
@@ -117,14 +119,15 @@ fn high_voltage(history: &MeasurementHistory) -> (SystemTask, ActuatorPlan) {
 }
 
 fn final_check_before_stabilising(history: &MeasurementHistory) -> (SystemTask, ActuatorPlan) {
+    let settings = settings::get();
     let plan = ActuatorPlan {
-        cooling: Some(Celsius(SATURATION_TARGET_C)),
-        iso_heater: Some(Celsius(IPA_HEATER_TARGET_C)),
+        cooling: Some(settings.saturation_target),
+        iso_heater: Some(settings.ipa_heater_target),
         high_voltage: true,
         iso_pump: false, lights: None, glass_heater: false,
     };
     match history.temps[CHAMBER_TEMP_IDX].get(0) {
-        Ok(m) if !m.value.0.is_nan() && m.value.0 <= SATURATION_TARGET_C + 2.0 =>
+        Ok(m) if !m.value.0.is_nan() && m.value.0 <= settings.saturation_target.0 + 2.0 =>
             (SystemTask::Stabilising, plan),
         _ => (SystemTask::Cooling(CoolingPhase::FinalCheckBeforeStabilising), plan),
     }

--- a/src/logic/phase_clock.rs
+++ b/src/logic/phase_clock.rs
@@ -283,18 +283,22 @@ mod tests {
 
     #[test]
     fn advance_stabilising_holds_outputs_without_timing_out() {
-        let history = MeasurementHistory::new();
-        let (next, plan) = advance(SystemTask::Stabilising, &history, 10 * 60 * 60 * 1000, 0); // 10h
-        assert_eq!(next, SystemTask::Stabilising);
-        assert_eq!(
-            plan,
-            ActuatorPlan {
-                cooling: Some(Celsius(SATURATION_TARGET_C)),
-                iso_heater: Some(Celsius(IPA_HEATER_TARGET_C)),
-                high_voltage: true,
-                iso_pump: false, lights: None, glass_heater: false,
-            }
-        );
+        // `Stabilising` lit `shared::settings::get()` (cf. control_loop.rs)
+        // — verrou nécessaire, cf. commentaire de `with_isolated_settings`.
+        crate::shared::settings::with_isolated_settings(|| {
+            let history = MeasurementHistory::new();
+            let (next, plan) = advance(SystemTask::Stabilising, &history, 10 * 60 * 60 * 1000, 0); // 10h
+            assert_eq!(next, SystemTask::Stabilising);
+            assert_eq!(
+                plan,
+                ActuatorPlan {
+                    cooling: Some(Celsius(SATURATION_TARGET_C)),
+                    iso_heater: Some(Celsius(IPA_HEATER_TARGET_C)),
+                    high_voltage: true,
+                    iso_pump: false, lights: None, glass_heater: false,
+                }
+            );
+        });
     }
 
     // ─── PhaseClock ─────────────────────────────────────────────────────────

--- a/src/logic/stopping.rs
+++ b/src/logic/stopping.rs
@@ -14,11 +14,10 @@
 //! `cooling.rs`. La transition vers `Idle` est gérée par l'appelant via le
 //! timeout de `SystemTask::durations()` (`STOP_EQUALIZE_FALLBACK_MS`).
 
-use crate::cloud_chamber_hal::units::Celsius;
-use crate::config::operating::SATURATION_TARGET_C;
 use crate::cloud_chamber_hal::actuators::ActuatorPlan;
 use crate::logic::probing::{MeasurementHistory, ProbingPlan};
 use crate::shared::data::SystemTask;
+use crate::shared::settings;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum StoppingPhase {
@@ -56,7 +55,7 @@ fn cut_high_voltage(_history: &MeasurementHistory) -> (SystemTask, ActuatorPlan)
     // dès l'entrée en phase. Froid encore actif (l'IPA continue de
     // circuler pendant la décharge) ; chauffage IPA coupé.
     (SystemTask::Stopping(StoppingPhase::CutHighVoltage), ActuatorPlan {
-        cooling: Some(Celsius(SATURATION_TARGET_C)), iso_heater: None, high_voltage: false,
+        cooling: Some(settings::get().saturation_target), iso_heater: None, high_voltage: false,
         iso_pump: false, lights: None, glass_heater: false,
     })
 }

--- a/src/shared/mod.rs
+++ b/src/shared/mod.rs
@@ -11,3 +11,6 @@
 
 /// Structures de données échangées entre les deux cœurs.
 pub mod data;
+
+/// Réglages opérateur courants, partagés entre l'écran de réglages et `logic/`.
+pub mod settings;

--- a/src/shared/settings.rs
+++ b/src/shared/settings.rs
@@ -1,0 +1,76 @@
+//! Point de partage des réglages opérateur.
+//!
+//! Même rôle que `SHARED_STATE` dans `data.rs`, et rangé au même endroit
+//! pour la même raison : `config::settings` définit le type `Settings`, il
+//! ne possède aucun état. C'est `shared` qui détient ce qui est global.
+//!
+//! # Pourquoi un static et pas un paramètre
+//!
+//! Faire descendre un `&Settings` obligerait `durations()`,
+//! `sensor_loss_abort()`, `advance()` et les trois `react_to()` de
+//! `SystemTask`, `CoolingPhase` et `StoppingPhase` à le porter. Ces
+//! valeurs ne sont pas des paramètres de ces fonctions, c'est justement
+//! pour ça qu'elles étaient des constantes. Le static garde les signatures
+//! intactes, et comme il démarre sur `Settings::defaults()`, les tests
+//! existants de `logic/` continuent de passer sans être touchés.
+//!
+//! # Pourquoi `Cell` et pas `RefCell`
+//!
+//! `data.rs` utilise `Mutex<RefCell<SharedState>>` parce que `SharedState`
+//! n'est pas `Copy` : il faut une `&mut` pour fusionner les mesures en
+//! place. `Settings` est `Copy` et tient sur quelques octets — on le lit et
+//! on l'écrit en entier, `Cell::get`/`set` suffisent.
+//!
+//! Ce n'est pas qu'une économie de compteur d'emprunt : `borrow_mut()`
+//! panique si un emprunt est déjà actif, et une panique dans la boucle de
+//! contrôle sur la puce, c'est un reset. Avec `Cell`, ce cas n'existe pas.
+
+use core::cell::Cell;
+use critical_section::Mutex;
+
+use crate::config::settings::Settings;
+
+/// Réglages courants. Écrits par l'écran de réglages, lus par `logic/`.
+///
+/// Passer par [`get`] et [`set`] plutôt que par ce static directement :
+/// personne d'autre n'a besoin de savoir qu'il y a une section critique
+/// dessous.
+static SETTINGS: Mutex<Cell<Settings>> = Mutex::new(Cell::new(Settings::defaults()));
+
+/// Copie des réglages courants.
+pub fn get() -> Settings {
+    critical_section::with(|cs| SETTINGS.borrow(cs).get())
+}
+
+/// Remplace les réglages courants.
+///
+/// L'écriture porte sur la struct entière : un lecteur voit soit l'ancienne
+/// version, soit la nouvelle, jamais un mélange des deux.
+pub fn set(settings: Settings) {
+    critical_section::with(|cs| SETTINGS.borrow(cs).set(settings));
+}
+
+// Pas de tests dans CE module : la valeur initiale est une constante
+// vérifiée à la compilation, et le câblage écran → static se constate sur
+// la machine. Mais `logic::cooling`/`stopping`/`control_loop` lisent
+// maintenant `get()` dans leur chemin normal, et `ui::screens::settings`
+// écrit via `set()` — plusieurs modules de test partagent donc ce static.
+// `cargo test` lance les tests en parallèle dans un même processus : sans
+// verrou, un test qui pousse une valeur ailleurs ferait échouer par
+// intermittence un test qui compare à `Settings::defaults()`. D'où
+// `with_isolated_settings`, à utiliser par tout test qui touche ce static
+// (lecture ou écriture) — même raison que
+// `control_loop::tests::with_isolated_shared_state` sur `SHARED_STATE`,
+// un static différent, donc un verrou différent.
+#[cfg(test)]
+static TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+
+/// Réinitialise `SETTINGS` à `Settings::defaults()` et exécute `body` sous
+/// verrou exclusif — chaque test démarre donc d'un état connu, indépendant
+/// de l'ordre ou du parallélisme d'exécution.
+#[cfg(test)]
+pub fn with_isolated_settings<T>(body: impl FnOnce() -> T) -> T {
+    let _guard = TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    set(Settings::defaults());
+    body()
+}

--- a/src/ui/router.rs
+++ b/src/ui/router.rs
@@ -7,6 +7,7 @@
 
 use embedded_graphics::{draw_target::DrawTarget, geometry::OriginDimensions, pixelcolor::Rgb565};
 
+use crate::config::settings::Settings;
 use crate::shared::data::SharedState;
 
 use super::interactions::{Click, NavAction, Rotary};
@@ -87,6 +88,14 @@ impl Screens {
             }
             None => {}
         }
+    }
+
+    /// Récupère une éventuelle demande de sauvegarde en flash levée par
+    /// l'écran de réglages. `None` la plupart du temps — à consommer
+    /// depuis la boucle principale (pas encore câblé : ce projet n'a pas
+    /// encore de point d'entrée matériel/`main.rs`, cf. `SettingsStore`).
+    pub fn take_save_request(&mut self) -> Option<Settings> {
+        self.settings.take_save_request()
     }
 
     /// Dessine l'écran actuellement affiché. `state` sert aux écrans

--- a/src/ui/screens/settings.rs
+++ b/src/ui/screens/settings.rs
@@ -2,10 +2,15 @@
 //! la sélection, cliquer entre en édition, tourner change la valeur, cliquer
 //! valide.
 //!
-//! Les valeurs vivent ici, initialisées depuis `crate::config::operating` au démarrage.
-//! Rien d'autre ne les lit encore : `logic/` continue de consulter les
-//! constantes. Le jour où une struct `Settings` partagée existera, ce tableau
-//! sera remplacé par un emprunt et le reste de l'écran ne bougera pas.
+//! Deux destinations pour une modification, et il ne faut pas les
+//! confondre. Chaque cran d'encodeur pousse la nouvelle valeur dans
+//! [`crate::shared::settings`], d'où `logic/` la lit au tour suivant : c'est
+//! ça, « les changements s'appliquent tout de suite ». La flash, elle, n'est
+//! écrite que sur la ligne « Save », et pas par cet écran — il lève un
+//! drapeau que la boucle principale récupère via
+//! [`SettingsScreen::take_save_request`], parce que c'est elle qui possède
+//! le `SettingsStore`. Même séparation que `ActuatorPlan`/`Actuators::apply`
+//! : l'écran décide, il n'agit pas.
 
 use core::fmt::Write;
 
@@ -20,7 +25,9 @@ use embedded_graphics::{
 };
 use heapless::String;
 
-use crate::config::operating::{IPA_HEATER_TARGET_C, PRECOOL_TARGET_C, SATURATION_TARGET_C, TARGET_CHAMBER_TEMP};
+use crate::cloud_chamber_hal::units::Celsius;
+use crate::config::settings::Settings;
+use crate::shared::settings as shared_settings;
 use crate::ui::interactions::{Click, NavAction, Rotary};
 use crate::ui::theme;
 
@@ -30,25 +37,48 @@ use super::widgets::{SettingLine, SettingLines};
 /// d'encodeur en mode édition.
 struct SettingSpec {
     label: &'static str,
+    get: fn(&Settings) -> Celsius,
+    set: fn(&mut Settings, Celsius),
     min: f32,
     max: f32,
     step: f32,
 }
 
 const SETTINGS: [SettingSpec; 4] = [
-    SettingSpec { label: "Chamber target", min: -50.0, max: 0.0, step: 0.5 },
-    SettingSpec { label: "Pre-cool target", min: -50.0, max: 0.0, step: 0.5 },
-    SettingSpec { label: "Saturation target", min: -50.0, max: 0.0, step: 0.5 },
-    SettingSpec { label: "IPA heater target", min: 0.0, max: 60.0, step: 0.5 },
+    SettingSpec {
+        label: "Chamber target",
+        get: |s| s.chamber_target,
+        set: |s, v| s.chamber_target = v,
+        min: -50.0, max: 0.0, step: 0.5,
+    },
+    SettingSpec {
+        label: "Pre-cool target",
+        get: |s| s.precool_target,
+        set: |s, v| s.precool_target = v,
+        min: -50.0, max: 0.0, step: 0.5,
+    },
+    SettingSpec {
+        label: "Saturation target",
+        get: |s| s.saturation_target,
+        set: |s, v| s.saturation_target = v,
+        min: -50.0, max: 0.0, step: 0.5,
+    },
+    SettingSpec {
+        label: "IPA heater target",
+        get: |s| s.ipa_heater_target,
+        set: |s, v| s.ipa_heater_target = v,
+        min: 0.0, max: 60.0, step: 0.5,
+    },
 ];
 
 const SCREEN_WIDTH: u32 = 320;
 const TOP_BAND_HEIGHT: u32 = 29;
 const LIST_TOP: i32 = 34;
 
-/// Dernière ligne de la liste : sortie de l'écran.
-const BACK_ROW: usize = SETTINGS.len();
-const N_ROWS: usize = SETTINGS.len() + 1;
+/// Les deux lignes d'action, à la suite des réglages.
+const SAVE_ROW: usize = SETTINGS.len();
+const BACK_ROW: usize = SETTINGS.len() + 1;
+const N_ROWS: usize = SETTINGS.len() + 2;
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 enum Mode {
@@ -59,21 +89,48 @@ enum Mode {
 pub struct SettingsScreen {
     selected: usize,
     mode: Mode,
-    values: [f32; SETTINGS.len()],
+    /// Copie de travail : c'est elle qu'on édite.
+    working: Settings,
+    /// Dernier état sauvegardé, pour savoir si quelque chose a bougé.
+    saved: Settings,
+    /// Sauvegarde demandée, en attente d'être récupérée par la boucle
+    /// principale.
+    save_requested: bool,
 }
 
 impl SettingsScreen {
+    /// Repart de ce que `logic/` utilise déjà — pas de la valeur par
+    /// défaut, pour ne pas donner l'impression de repartir de zéro si
+    /// l'écran a été quitté puis rouvert en session.
     pub fn new() -> Self {
+        let settings = shared_settings::get();
         Self {
             selected: 0,
             mode: Mode::Browsing,
-            values: [
-                TARGET_CHAMBER_TEMP,
-                PRECOOL_TARGET_C,
-                SATURATION_TARGET_C,
-                IPA_HEATER_TARGET_C,
-            ],
+            working: settings,
+            saved: settings,
+            save_requested: false,
         }
+    }
+
+    /// Récupère une demande de sauvegarde, et la consomme.
+    ///
+    /// L'écran ne peut pas écrire en flash lui-même : l'opération est
+    /// lente, doit tourner depuis la RAM interruptions coupées, et le
+    /// `SettingsStore` appartient à la boucle principale. L'écran se
+    /// contente de lever le drapeau.
+    pub fn take_save_request(&mut self) -> Option<Settings> {
+        if !self.save_requested {
+            return None;
+        }
+        self.save_requested = false;
+        self.saved = self.working;
+        Some(self.working)
+    }
+
+    /// Vrai si la copie de travail diffère du dernier état sauvegardé.
+    fn is_dirty(&self) -> bool {
+        self.working != self.saved
     }
 
     /// Déplace la valeur du réglage sélectionné d'un cran, bornée par sa spec.
@@ -82,8 +139,12 @@ impl SettingsScreen {
             return;
         }
         let spec = &SETTINGS[self.selected];
-        let value = self.values[self.selected] + steps * spec.step;
-        self.values[self.selected] = value.clamp(spec.min, spec.max);
+        let value = ((spec.get)(&self.working).0 + steps * spec.step).clamp(spec.min, spec.max);
+        (spec.set)(&mut self.working, Celsius(value));
+
+        // Publié tout de suite, pas à la sauvegarde : `logic/` reprendra la
+        // nouvelle valeur au tour suivant, y compris en plein cycle.
+        shared_settings::set(self.working);
     }
 
     pub fn draw<D>(&self, display: &mut D) -> Result<(), D::Error>
@@ -108,14 +169,18 @@ impl SettingsScreen {
         // Les valeurs sont formatées ici et empruntées par le widget : les
         // tampons doivent donc vivre jusqu'à la fin de la fonction.
         let mut buffers: [String<12>; SETTINGS.len()] = Default::default();
-        for (buffer, value) in buffers.iter_mut().zip(self.values.iter()) {
-            let _ = write!(buffer, "{value:.1} C");
+        for (buffer, spec) in buffers.iter_mut().zip(SETTINGS.iter()) {
+            let _ = write!(buffer, "{:.1} C", (spec.get)(&self.working).0);
         }
 
         let mut lines = [SettingLine { label: "", value: "" }; N_ROWS];
         for (i, spec) in SETTINGS.iter().enumerate() {
             lines[i] = SettingLine { label: spec.label, value: buffers[i].as_str() };
         }
+        lines[SAVE_ROW] = SettingLine {
+            label: "Save to flash",
+            value: if self.is_dirty() { "*" } else { "" },
+        };
         lines[BACK_ROW] = SettingLine { label: "Back", value: "" };
 
         SettingLines::<N_ROWS> {
@@ -147,11 +212,16 @@ impl Rotary for SettingsScreen {
 }
 
 impl Click for SettingsScreen {
-    /// Sur la ligne Back, quitte l'écran. Ailleurs, bascule entre navigation
-    /// et édition sans naviguer.
+    /// Sur la ligne Back, quitte l'écran. Sur la ligne Save, lève le
+    /// drapeau de sauvegarde sans changer de mode. Ailleurs, bascule entre
+    /// navigation et édition sans naviguer.
     fn click(&mut self) -> Option<NavAction> {
         if self.selected == BACK_ROW {
             return Some(NavAction::Back);
+        }
+        if self.selected == SAVE_ROW {
+            self.save_requested = true;
+            return None;
         }
         self.mode = match self.mode {
             Mode::Browsing => Mode::Editing,
@@ -167,102 +237,174 @@ impl Click for SettingsScreen {
 mod tests {
     use super::*;
     use embedded_graphics_simulator::{SimulatorDisplay, OutputSettingsBuilder};
+    use crate::shared::settings::with_isolated_settings;
 
     fn make_display() -> SimulatorDisplay<Rgb565> {
         SimulatorDisplay::new(Size::new(SCREEN_WIDTH, 240))
     }
 
+    // `SettingsScreen::new()` lit `shared_settings::get()`, et `nudge()`
+    // y écrit — un static partagé par tout le binaire de test. Chaque test
+    // ci-dessous passe par `with_isolated_settings` (verrou + retour aux
+    // défauts), sinon des tests parallèles (défaut de `cargo test`)
+    // pourraient se voir mutuellement une valeur laissée par l'autre. Même
+    // raison que `logic::control_loop::tests::with_isolated_shared_state`.
+
     #[test]
     fn browsing_moves_selection_without_changing_values() {
-        let mut screen = SettingsScreen::new();
-        let before = screen.values;
-        screen.right_turn();
-        assert_eq!(screen.selected, 1);
-        assert_eq!(screen.values, before);
+        with_isolated_settings(|| {
+            let mut screen = SettingsScreen::new();
+            let before = screen.working;
+            screen.right_turn();
+            assert_eq!(screen.selected, 1);
+            assert_eq!(screen.working, before);
+        });
     }
 
     #[test]
     fn selection_stops_at_both_ends() {
-        let mut screen = SettingsScreen::new();
-        screen.left_turn();
-        assert_eq!(screen.selected, 0);
-        for _ in 0..20 {
-            screen.right_turn();
-        }
-        assert_eq!(screen.selected, BACK_ROW);
+        with_isolated_settings(|| {
+            let mut screen = SettingsScreen::new();
+            screen.left_turn();
+            assert_eq!(screen.selected, 0);
+            for _ in 0..20 {
+                screen.right_turn();
+            }
+            assert_eq!(screen.selected, BACK_ROW);
+        });
     }
 
     #[test]
     fn click_enters_and_leaves_edit_mode() {
-        let mut screen = SettingsScreen::new();
-        assert!(screen.click().is_none());
-        assert_eq!(screen.mode, Mode::Editing);
-        assert!(screen.click().is_none());
-        assert_eq!(screen.mode, Mode::Browsing);
+        with_isolated_settings(|| {
+            let mut screen = SettingsScreen::new();
+            assert!(screen.click().is_none());
+            assert_eq!(screen.mode, Mode::Editing);
+            assert!(screen.click().is_none());
+            assert_eq!(screen.mode, Mode::Browsing);
+        });
     }
 
     #[test]
     fn editing_changes_the_selected_value_only() {
-        let mut screen = SettingsScreen::new();
-        let others = screen.values[1..].to_vec();
-        let _ = screen.click();
-        screen.right_turn();
-        assert_eq!(screen.values[0], TARGET_CHAMBER_TEMP + SETTINGS[0].step);
-        assert_eq!(screen.values[1..].to_vec(), others);
+        with_isolated_settings(|| {
+            let mut screen = SettingsScreen::new();
+            let before = screen.working;
+            let _ = screen.click();
+            screen.right_turn();
+            assert_eq!(screen.working.chamber_target, Celsius(before.chamber_target.0 + SETTINGS[0].step));
+            assert_eq!(screen.working.precool_target, before.precool_target);
+            assert_eq!(screen.working.saturation_target, before.saturation_target);
+            assert_eq!(screen.working.ipa_heater_target, before.ipa_heater_target);
+        });
     }
 
     #[test]
     fn value_stays_within_its_bounds() {
-        let mut screen = SettingsScreen::new();
-        let _ = screen.click();
-        for _ in 0..500 {
+        with_isolated_settings(|| {
+            let mut screen = SettingsScreen::new();
+            let _ = screen.click();
+            for _ in 0..500 {
+                screen.right_turn();
+            }
+            assert_eq!(screen.working.chamber_target, Celsius(SETTINGS[0].max));
+            for _ in 0..500 {
+                screen.left_turn();
+            }
+            assert_eq!(screen.working.chamber_target, Celsius(SETTINGS[0].min));
+        });
+    }
+
+    #[test]
+    fn nudging_publishes_to_shared_settings() {
+        with_isolated_settings(|| {
+            let mut screen = SettingsScreen::new();
+            let _ = screen.click();
             screen.right_turn();
-        }
-        assert_eq!(screen.values[0], SETTINGS[0].max);
-        for _ in 0..500 {
-            screen.left_turn();
-        }
-        assert_eq!(screen.values[0], SETTINGS[0].min);
+            assert_eq!(shared_settings::get().chamber_target, screen.working.chamber_target);
+        });
     }
 
     #[test]
     fn back_row_leaves_the_screen() {
-        let mut screen = SettingsScreen::new();
-        screen.selected = BACK_ROW;
-        assert_eq!(screen.click(), Some(NavAction::Back));
+        with_isolated_settings(|| {
+            let mut screen = SettingsScreen::new();
+            screen.selected = BACK_ROW;
+            assert_eq!(screen.click(), Some(NavAction::Back));
+        });
+    }
+
+    #[test]
+    fn save_row_flags_a_request_without_changing_mode() {
+        with_isolated_settings(|| {
+            let mut screen = SettingsScreen::new();
+            screen.selected = SAVE_ROW;
+            assert_eq!(screen.click(), None);
+            assert_eq!(screen.mode, Mode::Browsing);
+            assert_eq!(screen.take_save_request(), Some(screen.working));
+        });
+    }
+
+    #[test]
+    fn save_request_is_consumed_once() {
+        with_isolated_settings(|| {
+            let mut screen = SettingsScreen::new();
+            screen.selected = SAVE_ROW;
+            let _ = screen.click();
+            assert!(screen.take_save_request().is_some());
+            assert_eq!(screen.take_save_request(), None);
+        });
+    }
+
+    #[test]
+    fn dirty_only_after_an_edit() {
+        with_isolated_settings(|| {
+            let mut screen = SettingsScreen::new();
+            assert!(!screen.is_dirty());
+            let _ = screen.click();
+            screen.right_turn();
+            assert!(screen.is_dirty());
+            screen.selected = SAVE_ROW;
+            let _ = screen.click();
+            let _ = screen.take_save_request();
+            assert!(!screen.is_dirty());
+        });
     }
 
     #[test]
     fn draws_in_both_modes() {
-        let mut d = make_display();
-        let mut screen = SettingsScreen::new();
-        screen.draw(&mut d).unwrap();
-        let _ = screen.click();
-        screen.draw(&mut d).unwrap();
+        with_isolated_settings(|| {
+            let mut d = make_display();
+            let mut screen = SettingsScreen::new();
+            screen.draw(&mut d).unwrap();
+            let _ = screen.click();
+            screen.draw(&mut d).unwrap();
+        });
     }
-
 
     #[test]
     fn main_menu_screenshot() -> Result<(), core::convert::Infallible> {
-        let mut display = make_display();
+        with_isolated_settings(|| {
+            let mut display = make_display();
 
-        let main_menu_screen = SettingsScreen::new();
+            let main_menu_screen = SettingsScreen::new();
 
-        main_menu_screen.draw(&mut display)?;
+            main_menu_screen.draw(&mut display)?;
 
-        // SAVE SCREENSHOT
-        let output_settings = OutputSettingsBuilder::new()
-            .build();
+            // SAVE SCREENSHOT
+            let output_settings = OutputSettingsBuilder::new()
+                .build();
 
-        let path = std::env::args_os()
-            .nth(1)
-            .unwrap_or_else(|| "screenshots/SettingsMenu.png".into());
-        display
-            .to_rgb_output_image(&output_settings)
-            .save_png(&path)
-            .expect("failed to save screenshot");
+            let path = std::env::args_os()
+                .nth(1)
+                .unwrap_or_else(|| "screenshots/SettingsMenu.png".into());
+            display
+                .to_rgb_output_image(&output_settings)
+                .save_png(&path)
+                .expect("failed to save screenshot");
 
-        Ok(())
+            Ok(())
+        })
     }
 
 }


### PR DESCRIPTION
Réglages opérateur modifiables et persistants (flash)

Porte add-settings-storage sur l'organisation config/ actuelle de dev
(rebase mécanique impossible : conflit add/add sur
ui/screens/settings.rs dès le premier commit, développé
indépendamment des deux côtés).

- Settings déplacé dans config/settings.rs (pas cloud_chamber_hal,
  pour respecter le sens de dépendance HAL -> logic).
- Réduit à 4 cibles (chamber/precool/saturation/IPA) : sensor_loss_ms
  et regulation_band exclus, sans effet réel aujourd'hui.
- cooling.rs/stopping.rs/control_loop.rs lisent désormais les
  réglages en direct au lieu des constantes.
- Verrou de test ajouté pour le nouveau static partagé.

Co-authored-by: guerrouaz <guerrouazkynan@gmail.com>